### PR TITLE
Add save query results

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,15 @@ An MCP server for ClickHouse.
   * List all tables in a database.
   * Input: `database` (string): The name of the database.
 
+* `save_query_results`
+  * Execute a SELECT query and save results to a local file.
+  * Inputs:
+    * `query` (string): The SELECT query to execute
+    * `filepath` (string): Full absolute path where to save the file
+    * `format` (string): Output format - 'csv' or 'json' (default: 'csv')
+  * Returns details about the saved file including filepath and statistics
+  * Creates directories automatically if they don't exist
+
 ## Configuration
 
 1. Open the Claude Desktop configuration file located at:

--- a/mcp_clickhouse/__init__.py
+++ b/mcp_clickhouse/__init__.py
@@ -3,11 +3,13 @@ from .mcp_server import (
     list_databases,
     list_tables,
     run_select_query,
+    save_query_results,
 )
 
 __all__ = [
     "list_databases",
     "list_tables",
     "run_select_query",
+    "save_query_results",
     "create_clickhouse_client",
 ]

--- a/mcp_clickhouse/mcp_env.py
+++ b/mcp_clickhouse/mcp_env.py
@@ -97,7 +97,7 @@ class ClickHouseConfig:
         Default: 300 (ClickHouse default)
         """
         return int(os.getenv("CLICKHOUSE_SEND_RECEIVE_TIMEOUT", "300"))
-    
+
     @property
     def proxy_path(self) -> str:
         return os.getenv("CLICKHOUSE_PROXY_PATH")
@@ -123,7 +123,7 @@ class ClickHouseConfig:
         # Add optional database if set
         if self.database:
             config["database"] = self.database
-        
+
         if self.proxy_path:
             config["proxy_path"] = self.proxy_path
 


### PR DESCRIPTION
Add save_query_results Tool for Exporting Query Results

  This PR introduces a new MCP tool that enables users to execute ClickHouse queries and save the results directly to local files in CSV or JSON format.

  What's New

  - New tool: save_query_results - Execute SELECT queries and save results to files
  - Supported formats: CSV and JSON export
  - Auto directory creation: Automatically creates parent directories if they don't exist
  - Comprehensive testing: Added unit tests for both CSV and JSON formats